### PR TITLE
Upload cloudflare action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 .env.*
 !.env.cloudflare
 *.bak
+/.dev.vars

--- a/functions/uploadImage.js
+++ b/functions/uploadImage.js
@@ -1,0 +1,67 @@
+export async function onRequest(context) {
+  // Cloudflare function.
+  // Called from /uploadImage endpoint
+  // Relies on IMAGE_CHEST_KEY environment variable
+  // logs left in for debugging during integration but can be removed.
+
+  const imageChestKey = context.env.IMAGE_CHEST_KEY;
+
+  console.log(imageChestKey.length);
+  console.log("Using Authorization header:", `Bearer ${imageChestKey.substring(0, 5)}...`);
+
+  const incomingFormData = await context.request.formData();
+  const imageBlob = incomingFormData.get("image");
+  const title = "image.png";
+
+  if (!imageBlob) {
+    return new Response(JSON.stringify({ error: "No image data received" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  console.log("Received image type:", imageBlob.type);
+  console.log("Received image size:", imageBlob.size);
+
+  const imageChestUrl = `https://api.imgchest.com/v1/post`;
+
+  const body = new FormData();
+  body.append("title", title);
+  body.append("images[]", imageBlob, title || "image.png");
+
+  try {
+    const response = await fetch(imageChestUrl, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${imageChestKey}`,
+      },
+      body: body,
+    });
+
+    console.log("Response status:", response.status);
+    console.log("Response headers:", Object.fromEntries(response.headers));
+
+    const responseText = await response.text();
+    console.log("Response body (first characters):", responseText.substring(0, 2000));
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        console.error("Authentication failed. Please check your API key.");
+      }
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const responseJson = JSON.parse(responseText);
+    console.log("Parsed JSON:", responseJson);
+    return new Response(responseJson["data"]["images"][0]["link"], {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("Error:", error);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -453,6 +453,24 @@
     previewFrame.getPDF(fileName, elementNamesInIframe, pageType, 2.48, 3.465);
   }
 
+  // function uploadScreenshot() {
+  //   // Unused here as an example code.
+  //   let fileName;
+  //   if (powerCards.spiritName) {
+  //     fileName = powerCards.spiritName.replaceAll(" ", "_") + "_power_card";
+  //   } else {
+  //     fileName = "power_card";
+  //   }
+  //
+  //   const urls = [];
+  //   for (let i = 0; i < powerCards.cards.length; i++) {
+  //     const elementNameInFrame = `#card${i}`;
+  //     const url = previewFrame.uploadScreenshot(fileName, elementNameInFrame);
+  //     urls.push(url);
+  //   }
+  //   return urls;
+  // }
+
   function printToPDFLetter() {
     printToPDF("letter");
   }

--- a/src/routes/power-cards/power-card.svelte
+++ b/src/routes/power-cards/power-card.svelte
@@ -10,7 +10,7 @@
     card.speed = powerSpeed;
     powerCards = powerCards;
 
-    //update tempalte
+    //update template
     let previewFrame = document.getElementById("preview-iframe").contentWindow;
     let templateCard = previewFrame.document.getElementById("card" + card.id);
     templateCard.removeAttribute("class");
@@ -21,7 +21,7 @@
     card.targetTitle = targetTitle;
     powerCards = powerCards;
 
-    //update tempalte
+    //update template
     let previewFrame = document.getElementById("preview-iframe").contentWindow;
     let templateCard = previewFrame.document.getElementById("card" + card.id + "targettitle");
     templateCard.innerHTML = targetTitle;

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,9 @@ const config = {
       allow: ["docs/"],
     },
   },
+  build: {
+    sourcemap: true,
+  },
 };
 
 export default config;


### PR DESCRIPTION
I left in a comment with example code in power-cards/index and some console logs in the function for debugging if there's trouble with integration. They can all be removed when not needed.

An API key can be made at https://imgchest.com/profile/security 
The service is free and will likely never have rate limit problems.

Cloudflare can be given the api key as an env var called IMAGE_CHEST_KEY
The /uploadImage endpoint will call a function in cloudflare, which is hosting the website. This way cloudflare can call the api with the key, without the key being exposed in the frontend. If the key was anywhere in the code, someone could fetch it out of the source that was sent to the browser.