### PR TITLE
Fix tts export with null child.nodeValue

### DIFF
--- a/src/lib/tts.js
+++ b/src/lib/tts.js
@@ -66,7 +66,7 @@ export const getThresholdTTSJSON = (
         lastNum = 0;
       } else if (!isNaN(child.nodeValue)) {
         // Used in power card thresholds
-        lastNum = child.nodeValue.trim();
+        lastNum = child.nodeValue?.trim();
       } else if (child.tagName === "THRESHOLD-OR") {
         j++;
         elCountArrays.push([0, 0, 0, 0, 0, 0, 0, 0]);


### PR DESCRIPTION
The website has a null value for `child.nodeValue` within the `src/lib/tts.js` file that prevented exporting the `Spirit Board Play Side` for use in TTS.

I was able to fork and verify these changes worked to export the tts files locally.