### PR TITLE
fix browser compat, scoping bugs, and style injection guard

### DIFF
--- a/src/lib/google-drive.js
+++ b/src/lib/google-drive.js
@@ -2,6 +2,7 @@
 import { showToast } from "./alert.js";
 
 function injectDriveStyles() {
+  if (document.getElementById("drive-modal-styles")) return;
   const css = `
     .drive-modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0, 0, 0, 0.5); z-index: 9999; display: flex; justify-content: center; align-items: center; }
     .drive-modal { background: white; width: 400px; padding: 20px; border-radius: 8px; box-shadow: 0 4px 15px rgba(0,0,0,0.2); font-family: sans-serif; }
@@ -19,6 +20,7 @@ function injectDriveStyles() {
     .btn-group button { padding: 8px 15px; cursor: pointer; margin-left: 5px; }
   `;
   const style = document.createElement("style");
+  style.id = "drive-modal-styles";
   style.appendChild(document.createTextNode(css));
   document.head.appendChild(style);
 }

--- a/src/routes/lib.js
+++ b/src/routes/lib.js
@@ -300,6 +300,11 @@ export const nextNode = (event) => {
       let regFindNumbers = /^\d+|\d+\b|\d+(?=\w)/g;
       let numMatches = currentID.match(regFindNumbers);
 
+      // Tab-key navigation between form fields.
+      // Each case maps a field ID (with digits stripped) to the next field to focus.
+      // IMPORTANT: Adding a new form field requires adding a new case here.
+      // Silent failure: if the resolved focusID doesn't exist in the DOM, focus is
+      // simply not moved (see "No next node" branch below). No error is thrown.
       switch (numlessID) {
         //Board - Special Rule
         case "ruleNameInput":

--- a/static/template/_global/js/adversary.js
+++ b/static/template/_global/js/adversary.js
@@ -112,7 +112,7 @@ let localize = {
 };
 
 function startMain() {
-  quickAdversary = document.querySelectorAll("quick-adversary")[0];
+  let quickAdversary = document.querySelectorAll("quick-adversary")[0];
 
   if (quickAdversary) {
     var adversary = document.createElement("adversary");
@@ -135,15 +135,15 @@ function startMain() {
 
 function buildAdversary(quickAdversary) {
   lang = quickAdversary.getAttribute("lang");
-  adversaryName = quickAdversary.getAttribute("name");
-  flagImage = quickAdversary.getAttribute("flag-image");
-  baseDifficulty = quickAdversary.getAttribute("base-difficulty");
+  let adversaryName = quickAdversary.getAttribute("name");
+  let flagImage = quickAdversary.getAttribute("flag-image");
+  let baseDifficulty = quickAdversary.getAttribute("base-difficulty");
   let baseDifficultyText = "";
   if (baseDifficulty) {
     baseDifficultyText = `<adversary-base-dif>${localize[lang]["baseDifficulty"]}  <num>${baseDifficulty}</num></adversary-base-dif>`;
   }
 
-  lossCondition = quickAdversary.querySelectorAll("loss-condition")[0];
+  let lossCondition = quickAdversary.querySelectorAll("loss-condition")[0];
   let lossConditionTitle = lossCondition.getAttribute("name");
   let lossConditionAlt = lossCondition.getAttribute("alternate") ? true : false;
   let lossConditionHeading = localize[lang]["additionalLossCondition"];
@@ -161,11 +161,11 @@ function buildAdversary(quickAdversary) {
     topInfoClass = "class='no-loss-condition'";
     lossConditionRules = localize[lang]["none"];
   }
-  escalation = quickAdversary.querySelectorAll("escalation-effect")[0];
+  let escalation = quickAdversary.querySelectorAll("escalation-effect")[0];
 
-  levels = quickAdversary.querySelectorAll("level");
+  let levels = quickAdversary.querySelectorAll("level");
 
-  html = `
+  let html = `
     <adversary-title>${adversaryName}</adversary-title>
     <img class="flag" src="${flagImage}" />
     ${baseDifficultyText}
@@ -209,7 +209,7 @@ function buildAdversary(quickAdversary) {
 }
 
 function buildLevel(quickLevel) {
-  fearCards = quickLevel.getAttribute("fear-cards");
+  let fearCards = quickLevel.getAttribute("fear-cards");
   fearCards = fearCards.replaceAll(",", "/");
   let pullNumbersRegex = /\d+/g;
   let fearCardNum = "";
@@ -228,7 +228,7 @@ function buildLevel(quickLevel) {
     )}:</strong> ${quickLevel.getAttribute("rules2")}</rule>`;
   }
 
-  levelHTML = `<level>
+  let levelHTML = `<level>
         <div>${quickLevel.tagName.at(-1)}<level-difficulty>(<num>${quickLevel.getAttribute(
     "difficulty"
   )}</num>)</level-difficulty></div>

--- a/static/template/_global/js/aspect.js
+++ b/static/template/_global/js/aspect.js
@@ -5,7 +5,7 @@ function startMain() {
   console.log("aspect startMain");
   var aspects = document.querySelectorAll("aspect");
   if (aspects[0].hasAttribute("lang")) {
-    lang = aspects[0].getAttribute("lang");
+    let lang = aspects[0].getAttribute("lang");
     console.log("found language " + lang);
   }
   for (var i = 0; i < aspects.length; i++) {
@@ -179,13 +179,13 @@ function resizeAspect(aspects) {
     }
 
     const aspectRules = aspectSubtext.getElementsByTagName("aspect-rule");
-    for (i = 0; i < aspectRules.length; i++) {
+    for (let i = 0; i < aspectRules.length; i++) {
       balanceText(aspectRules[i]);
     }
 
     const growthTables = aspect.getElementsByTagName("growth-table");
     if (growthTables) {
-      for (i = 0; i < growthTables.length; i++) {
+      for (let i = 0; i < growthTables.length; i++) {
         if (checkOverflowWidth(growthTables[i].parentNode, 0)) {
           growthTables[i].classList.add("tight");
         }

--- a/static/template/_global/js/blight_card.js
+++ b/static/template/_global/js/blight_card.js
@@ -1,3 +1,5 @@
+let tempalteBlightCard;
+
 async function startMain() {
   // window.onload = function startMain() {
   //remove the window.onload when transferring over to Builder
@@ -45,7 +47,7 @@ function buildBuildCard(template) {
     blightCard.classList.add("still-healthy"); //this doesn't exist yet so we can't add
   }
 
-  html = `<blight-heading>${headingText}</blight-heading>
+  let html = `<blight-heading>${headingText}</blight-heading>
     <blight-banner><effect-name>${effectName}</effect-name>
     <effect>${effectHTML}</effect><blight-banner-after></blight-banner-after></blight-banner>
     <per-player-text>

--- a/static/template/_global/js/board_lore.js
+++ b/static/template/_global/js/board_lore.js
@@ -27,10 +27,10 @@ function startMain() {
 function resize() {
   dynamicSizing(document.querySelectorAll("lore-description")[0]);
 
-  board = document.querySelectorAll("board")[0];
-  secondContainer = document.querySelectorAll("second-section-container")[0];
-  setup = document.querySelectorAll("setup-description")[0];
-  playstyle = document.querySelectorAll("play-style-description")[0];
+  let board = document.querySelectorAll("board")[0];
+  let secondContainer = document.querySelectorAll("second-section-container")[0];
+  let setup = document.querySelectorAll("setup-description")[0];
+  let playstyle = document.querySelectorAll("play-style-description")[0];
 
   //Optional: Finder type boards
   let finder = board.getAttribute("finderstyle") ? true : false;
@@ -54,11 +54,11 @@ function resize() {
   // dynamicSizing(document.querySelectorAll('setup-description')[0]);
   // dynamicSizing(document.querySelectorAll('play-style-description')[0]);
 
-  loreImage = document.querySelectorAll("img")[0];
+  let loreImage = document.querySelectorAll("img")[0];
   var loreOverlay = document.createElement("lore-overlay");
   loreImage.after(loreOverlay);
   var imgWidth = window.getComputedStyle(loreImage, null).getPropertyValue("width");
-  imageScale = loreImage.getAttribute("scale");
+  let imageScale = loreImage.getAttribute("scale");
   if (imageScale) {
     if (isNaN(imageScale)) {
       loreImage.style.width = imageScale;
@@ -164,22 +164,22 @@ function buildLoreBoard() {
   defenseTag.style.height = defenseValue * 10 + "%";
   utilityTag.style.height = utilityValue * 10 + "%";
 
-  uses = document.getElementsByTagName("summary-of-powers")[0].getAttribute("uses");
-  table = document.getElementsByClassName("powers-summary")[0];
-  topRow = table.getElementsByTagName("tr")[0];
-  note = document.getElementsByTagName("note")[0];
+  let uses = document.getElementsByTagName("summary-of-powers")[0].getAttribute("uses");
+  let table = document.getElementsByClassName("powers-summary")[0];
+  let topRow = table.getElementsByTagName("tr")[0];
+  let note = document.getElementsByTagName("note")[0];
   if (note) {
     console.log("found note");
     table.classList.add("has-note");
-    noteRow = document.createElement("tr");
+    let noteRow = document.createElement("tr");
     noteRow.className = "note-row";
     topRow.parentNode.insertBefore(noteRow, topRow);
     noteRow.appendChild(document.createElement("td"));
-    noteCol = document.createElement("td");
+    let noteCol = document.createElement("td");
     noteCol.colSpan = "5";
     noteCol.classList.add("note");
     noteRow.appendChild(noteCol);
-    noteWrap = document.createElement("note-wrap");
+    let noteWrap = document.createElement("note-wrap");
     noteCol.appendChild(note);
     // noteWrap.innerHTML = note.textContent;
 
@@ -188,21 +188,21 @@ function buildLoreBoard() {
     console.log("no note");
     console.log(note);
   }
-  countRows = table.querySelectorAll("tr").length;
+  let countRows = table.querySelectorAll("tr").length;
   if (uses) {
     table.classList.add("has-uses");
     topRow = table.getElementsByTagName("tr")[0]; // reset top row in case note was added
-    lineCol = document.createElement("td");
+    let lineCol = document.createElement("td");
     lineCol.className = "power-divider";
     lineCol.rowSpan = countRows - 1;
-    usesCol = document.createElement("td");
+    let usesCol = document.createElement("td");
     usesCol.rowSpan = countRows; //if we added a note, span that column too
     usesCol.className = "uses-icon";
     usesCol.append(localize[lang]["uses"]);
-    usesList = uses.split(",");
-    iconHolder = document.createElement("uses-icon-holder");
+    let usesList = uses.split(",");
+    let iconHolder = document.createElement("uses-icon-holder");
     for (let i = 0; i < usesList.length; i++) {
-      usesIcon = document.createElement("icon");
+      let usesIcon = document.createElement("icon");
       usesIcon.className = usesList[i] + " uses-icon";
       iconHolder.append(usesIcon);
     }
@@ -213,9 +213,9 @@ function buildLoreBoard() {
 
   //Translate other non-english headings
   if (lang !== "en") {
-    setupText = document.getElementsByTagName("setup-title")[0];
+    let setupText = document.getElementsByTagName("setup-title")[0];
     setupText.innerHTML = localize[lang]["setup"] + ":";
-    playstyleText = document.getElementsByTagName("play-style-title")[0];
+    let playstyleText = document.getElementsByTagName("play-style-title")[0];
     playstyleText.innerHTML = localize[lang]["playstyle"] + ":";
   }
 }

--- a/static/template/_global/js/card.js
+++ b/static/template/_global/js/card.js
@@ -94,20 +94,20 @@ function constructCard(data, cardIndex) {
 
 function resize() {
   //Name
-  nameBlocks = document.querySelectorAll("name");
-  nameHolders = document.querySelectorAll("name-holder");
+  let nameBlocks = document.querySelectorAll("name");
+  let nameHolders = document.querySelectorAll("name-holder");
   for (let i = 0; i < nameBlocks.length; i++) {
     dynamicSizing(nameBlocks[i], nameHolders[i]);
     balanceText(nameBlocks[i], 33);
   }
 
   //Rules & Threshold
-  rulesContainers = document.querySelectorAll("rules-container");
+  let rulesContainers = document.querySelectorAll("rules-container");
 
   for (let i = 0; i < rulesContainers.length; i++) {
-    rulesBlock = rulesContainers[i].querySelectorAll("rules")[0];
-    thresholdBlock = rulesContainers[i].querySelectorAll("threshold")[0];
-    limitingBlock = thresholdBlock == undefined ? rulesContainers[i] : thresholdBlock;
+    let rulesBlock = rulesContainers[i].querySelectorAll("rules")[0];
+    let thresholdBlock = rulesContainers[i].querySelectorAll("threshold")[0];
+    let limitingBlock = thresholdBlock == undefined ? rulesContainers[i] : thresholdBlock;
     let j = 0;
     while (checkOverflowHeight(limitingBlock)) {
       var style = window.getComputedStyle(rulesBlock, null).getPropertyValue("font-size");
@@ -130,7 +130,7 @@ function resize() {
   }
 
   // Set widths for image export
-  rulesDivs = Array.from(rulesContainers[0].querySelectorAll("div"));
+  let rulesDivs = Array.from(rulesContainers[0].querySelectorAll("div"));
 
   rulesDivs.forEach((ruleDiv) => {
     ruleDiv.style.width =
@@ -140,7 +140,7 @@ function resize() {
   });
 
   //Images (this seems to be an incomplete idea)
-  imageContainers = document.querySelectorAll("img");
+  let imageContainers = document.querySelectorAll("img");
   for (let i = 0; i < imageContainers.length; i++) {}
 }
 
@@ -230,7 +230,7 @@ function getData(quickCard, cardIndex) {
 function getRulesNew(quickCard, cardIndex) {
   var rules = quickCard.querySelectorAll("rules")[0];
 
-  rulesHTML = "<rules>" + getFormatRulesText(rules.innerHTML) + "</rules>";
+  let rulesHTML = "<rules>" + getFormatRulesText(rules.innerHTML) + "</rules>";
   rulesHTML = `<rules id='card${cardIndex}rules'>${getFormatRulesText(rules.innerHTML)}</rules>`;
 
   var thresholds = quickCard.querySelectorAll("threshold");
@@ -246,7 +246,7 @@ function getRulesNew(quickCard, cardIndex) {
 }
 
 function getFormatRulesText(rulesHTML) {
-  ruleLines = rulesHTML.split("\n");
+  let ruleLines = rulesHTML.split("\n");
   let rulesFormatted = "";
   for (let i = 0; i < ruleLines.length; i++) {
     if (ruleLines[i] && ruleLines[i].trim().length) {

--- a/static/template/_global/js/card.js
+++ b/static/template/_global/js/card.js
@@ -22,7 +22,7 @@ function startMain() {
   }
 
   const cards = document.querySelectorAll("card");
-  for (i = 0; i < cards.length; ++i) {
+  for (let i = 0; i < cards.length; ++i) {
     cards[i].innerHTML = replaceIcon(cards[i].innerHTML);
     cards[i].style.zIndex = i + 1;
   }

--- a/static/template/_global/js/common.js
+++ b/static/template/_global/js/common.js
@@ -1,3 +1,7 @@
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function replaceIcon(html) {
   var result = html;
 
@@ -40,10 +44,8 @@ function replaceIcon(html) {
   ]);
 
   for (var match of matchs || []) {
-    iconHtml = getIconHTML(match);
-    // console.log (`Replacing ${RegExp(match, "ig")} with ${iconHtml}`)
-    // console.log (`Escaping ${match} with ${RegExp.escape(match)}`)
-    result = result.replace(new RegExp(RegExp.escape(match), "ig"), iconHtml);
+    const iconHtml = getIconHTML(match);
+    result = result.replace(new RegExp(escapeRegExp(match), "ig"), iconHtml);
   }
 
   return result;
@@ -184,7 +186,7 @@ function replaceIcon(html) {
       num_val = energy_num;
       console.log(`${HTMLTag} ${num_val} ${iconName}`);
     } else if (iconName.startsWith("gain-energy-")) {
-      energy_num = iconName.substring(12);
+      let energy_num = iconName.substring(12);
       if (isNaN(energy_num)) {
       } else {
         HTMLTag = "custom-energy"; //"<growth-energy><value>" + flatEnergy + "</value></growth-energy>"

--- a/static/template/_global/js/event_card.js
+++ b/static/template/_global/js/event_card.js
@@ -1,3 +1,5 @@
+let templateEventCard;
+
 async function startMain() {
   console.log("Start Main: Event Card");
 
@@ -48,7 +50,7 @@ function buildCard(template) {
 
   const tokenEvents = document.querySelectorAll("token-event");
 
-  html = `<event-body class="${eventType} ${eventSubtype}">
+  let html = `<event-body class="${eventType} ${eventSubtype}">
           <event-header class="title">${eventName}</event-header>
           <effect class = "title"> ${eventLore} </effect>`;
 

--- a/static/template/_global/js/fear_card.js
+++ b/static/template/_global/js/fear_card.js
@@ -3,7 +3,7 @@ async function startMain() {
   // window.onload is for template mode
   console.log("Start Main: Fear Card");
 
-  templateFearCard = document.querySelectorAll("template-fear-card")[0];
+  let templateFearCard = document.querySelectorAll("template-fear-card")[0];
   templateFearCard = buildFearCard(templateFearCard);
 
   // if (templateFearCard) {

--- a/static/template/_global/js/invader_card.js
+++ b/static/template/_global/js/invader_card.js
@@ -3,7 +3,7 @@ async function startMain() {
   // window.onload is for template mode
   console.log("Start Main: Invader Card");
 
-  templateInvaderCard = document.querySelectorAll("template-invader-card")[0];
+  let templateInvaderCard = document.querySelectorAll("template-invader-card")[0];
   templateInvaderCard = buildInvaderCard(templateInvaderCard);
 
   var html = templateInvaderCard.innerHTML;

--- a/static/template/_global/js/scenario.js
+++ b/static/template/_global/js/scenario.js
@@ -125,7 +125,7 @@ function buildScenario(quickScenario) {
       if (comment.classList.contains("image")) {
         comment.innerHTML = "";
         console.log(comment);
-        commentImage = document.createElement("img");
+        let commentImage = document.createElement("img");
         comment.appendChild(commentImage);
         commentImage.setAttribute("src", comment.getAttribute("imgsrc"));
       }


### PR DESCRIPTION
- common.js: add escapeRegExp polyfill to replace unsupported RegExp.escape() (only available in Chrome 136+/Firefox 131+/Safari 18.2+); fix implicit globals iconHtml (const) and energy_num (let)
- card.js: fix implicit global loop counter (for i -> for let i)
- lib.js: add explanatory comment to tab-navigation switch in nextNode()
- google-drive.js: guard injectDriveStyles() against duplicate style injection