### PR TITLE
feat: replace nextNode switch with data-next-field attributes

### DIFF
--- a/src/lib/auto-complete/index.svelte
+++ b/src/lib/auto-complete/index.svelte
@@ -12,6 +12,8 @@
   export let classNames = "";
   export let showListImmediately = false;
   export let additionalOnBlurFunction = () => {};
+  export let nextField = "";
+  export let nextFieldDefault = "";
 
   let initialOnBlurFunction = () => {};
 
@@ -348,6 +350,8 @@
       type="text"
       {placeholder}
       autocomplete="off"
+      data-next-field={nextField}
+      data-next-field-default={nextFieldDefault}
       on:input={handleInputAndFocus}
       on:focus={handleInputAndFocus}
       on:blur={closeAutoComplete}
@@ -359,6 +363,8 @@
       class={`textarea ${classNames}`}
       {placeholder}
       autocomplete="off"
+      data-next-field={nextField}
+      data-next-field-default={nextFieldDefault}
       on:input={handleInputAndFocus}
       on:focus={handleInputAndFocus}
       on:blur={closeAutoComplete}

--- a/src/routes/adversary/adversary-levels.svelte
+++ b/src/routes/adversary/adversary-levels.svelte
@@ -87,6 +87,7 @@
             class="input is-small"
             type="text"
             placeholder="Name"
+            data-next-field="levelDifficultyInput{i}"
             on:keydown={nextNode}
             on:focus={selectNode}
             bind:value={level.name} />
@@ -97,6 +98,7 @@
             class="input is-small"
             type="text"
             placeholder="Difficulty"
+            data-next-field="levelFearInput{i}"
             on:keydown={nextNode}
             on:focus={selectNode}
             bind:value={level.difficulty} />
@@ -107,6 +109,7 @@
             class="input is-small"
             type="text"
             placeholder="Fear Cards"
+            data-next-field="levelEffectInput{i}"
             on:keydown={nextNode}
             on:focus={selectNode}
             bind:value={level.fearCards} />
@@ -118,6 +121,8 @@
           elementType="textarea"
           classNames="is-small"
           placeholder="Effect"
+          nextField="levelSecondNameInput{i}"
+          nextFieldDefault="levelNameInput{i + 1}"
           validAutoCompleteValues={iconValuesSorted}
           bind:value={level.effect} />
       </div>
@@ -128,6 +133,7 @@
               id={`levelSecondNameInput${i}`}
               class="input is-small"
               type="text"
+              data-next-field="levelSecondEffectInput{i}"
               on:keydown={nextNode}
               on:focus={selectNode}
               placeholder="2nd Rule Name"
@@ -144,6 +150,7 @@
             elementType="textarea"
             classNames="is-small"
             placeholder="2nd Rule Effect"
+            nextField="levelNameInput{i + 1}"
             validAutoCompleteValues={iconValuesSorted}
             bind:value={level.effect2} />
         </div>

--- a/src/routes/adversary/name-loss-escalation.svelte
+++ b/src/routes/adversary/name-loss-escalation.svelte
@@ -41,6 +41,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="baseDifficulty"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={adversary.nameLossEscalation.name} />
@@ -51,6 +52,7 @@
           class="input"
           type="text"
           placeholder="Difficulty"
+          data-next-field="LossConditionInput"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={adversary.nameLossEscalation.baseDif} />
@@ -81,6 +83,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="lossConditionEffectInput"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={adversary.nameLossEscalation.lossCondition.name} />
@@ -92,6 +95,7 @@
         elementType="textarea"
         placeholder="Effect"
         classNames="is-small"
+        nextField="EscalationInput"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={adversary.nameLossEscalation.lossCondition.effect} />
     </div>
@@ -108,6 +112,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="escalationEffectInput"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={adversary.nameLossEscalation.escalation.name} />

--- a/src/routes/aspect/aspect-effects.svelte
+++ b/src/routes/aspect/aspect-effects.svelte
@@ -233,6 +233,7 @@
                   class="input is-small"
                   type="text"
                   placeholder="ie. Replaces Special Rule"
+                  data-next-field="part{k}RulesReplacedInput{i}"
                   on:keydown={nextNode}
                   on:focus={selectNode}
                   bind:value={replacement.aspectRelacement} />
@@ -254,6 +255,8 @@
                   class="input is-small"
                   type="text"
                   placeholder="ie. The Name of a Spirit's Special Rule"
+                  data-next-field="part{k}ReplacesInput{i + 1}"
+                  data-next-field-default="part{k}addReplacement"
                   on:keydown={nextNode}
                   on:focus={selectNode}
                   bind:value={replacement.rulesReplaced} />
@@ -288,6 +291,7 @@
               class="input"
               type="text"
               placeholder="Name"
+              data-next-field={`part${k}RuleEffectInput${i}`}
               on:keydown={nextNode}
               on:focus={selectNode}
               bind:value={rule.name} />

--- a/src/routes/aspect/name-replacements.svelte
+++ b/src/routes/aspect/name-replacements.svelte
@@ -65,6 +65,8 @@
             class="input"
             type="text"
             placeholder="Name"
+            data-next-field="part0ReplacesInput0"
+            data-next-field-default="aspectSpiritName"
             on:keydown={nextNode}
             on:focus={selectNode}
             bind:value={aspect.info.aspectName} />

--- a/src/routes/blight-card/name-effects.svelte
+++ b/src/routes/blight-card/name-effects.svelte
@@ -43,6 +43,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="blightCardBlightPerPlayer"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={blightCard.card.cardName} />
@@ -53,6 +54,7 @@
           class="input"
           type="text"
           placeholder="Blight Per Player"
+          data-next-field="blightCardEffect"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={blightCard.card.blightPerPlayer} />

--- a/src/routes/event-card/event-type.svelte
+++ b/src/routes/event-card/event-type.svelte
@@ -144,6 +144,7 @@
             class="input "
             type="text"
             placeholder="Overall event name"
+            data-next-field="eventCardLore"
             on:keydown={nextNode}
             bind:value={eventCard.card.name} />
         </div>
@@ -157,6 +158,7 @@
             id="eventCardLore"
             elementType="textarea"
             placeholder="Lore description of the event"
+            nextField="subeventName0"
             validAutoCompleteValues={iconValuesSorted}
             bind:value={eventCard.card.lore} />
         </div>
@@ -247,6 +249,7 @@
               class="input  is-small"
               type="text"
               placeholder="Overall event name"
+              data-next-field={`subeventEffect${i}`}
               on:keydown={nextNode}
               bind:value={event.name} />
           </div>
@@ -262,6 +265,7 @@
             elementType="textarea"
             classNames="is-small"
             placeholder="Lore description of the event"
+            nextField="subeventName{i + 1}"
             validAutoCompleteValues={iconValuesSorted}
             bind:value={event.effect} />
         </div>

--- a/src/routes/event-card/tokenevents.svelte
+++ b/src/routes/event-card/tokenevents.svelte
@@ -67,6 +67,7 @@
             class="input  is-small"
             type="text"
             placeholder="Subevent name"
+            data-next-field={`tokenEventTokens${i}`}
             on:keydown={nextNode}
             bind:value={event.name} />
         </div>
@@ -81,6 +82,7 @@
             class="input  is-small"
             type="text"
             placeholder="Tokens, use commas (ie. disease,strife)"
+            data-next-field={`tokenEventEffects${i}`}
             on:keydown={nextNode}
             bind:value={event.tokens} />
         </div>
@@ -96,6 +98,7 @@
           elementType="textarea"
           classNames="is-small"
           placeholder="Effects"
+          nextField="tokenEventName{i + 1}"
           validAutoCompleteValues={iconValuesSorted}
           bind:value={event.effect} />
       </div>

--- a/src/routes/fear-card/name-effects.svelte
+++ b/src/routes/fear-card/name-effects.svelte
@@ -34,6 +34,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="fearCardEffect1"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={fearCard.card.cardName} />
@@ -52,6 +53,7 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
+        nextField="fearCardEffect2"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={fearCard.card.level1} />
     </div>
@@ -61,6 +63,7 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
+        nextField="fearCardEffect3"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={fearCard.card.level2} />
     </div>

--- a/src/routes/incarna-token/name-effects.svelte
+++ b/src/routes/incarna-token/name-effects.svelte
@@ -37,6 +37,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="incarnaTokenIcon"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={incarnaToken.incarna.name} />
@@ -62,6 +63,7 @@
           class="input"
           type="text"
           placeholder="Incarna Icon"
+          data-next-field="incarnaTokenToken"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={incarnaToken.incarna.icon} />
@@ -75,6 +77,7 @@
           class="input"
           type="text"
           placeholder="Token (ie. beasts or sacred-site, etc)"
+          data-next-field="incarnaTokenEmpoweredToken"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={incarnaToken.incarna.token} />

--- a/src/routes/lib.js
+++ b/src/routes/lib.js
@@ -292,6 +292,27 @@ export const nextNode = (event) => {
   if (event.key === "Enter") {
     console.log(event);
     if (!event.srcElement.classList.contains("textarea") || event.shiftKey) {
+      event.preventDefault();
+      const el = event.target;
+      let focusID = el.dataset.nextField;
+      if (!focusID) return;
+      if (document.getElementById(focusID) === null) {
+        focusID = el.dataset.nextFieldDefault || "";
+      }
+      if (focusID && document.getElementById(focusID) !== null) {
+        document.getElementById(focusID).focus();
+      } else {
+        console.log("No next node");
+      }
+    }
+  }
+};
+
+// eslint-disable-next-line no-unused-vars
+const nextNode_DEPRECATED = (event) => {
+  if (event.key === "Enter") {
+    console.log(event);
+    if (!event.srcElement.classList.contains("textarea") || event.shiftKey) {
       // For textarea, require SHIFT to advance
       event.preventDefault();
       let currentID = event.target.id;
@@ -300,11 +321,6 @@ export const nextNode = (event) => {
       let regFindNumbers = /^\d+|\d+\b|\d+(?=\w)/g;
       let numMatches = currentID.match(regFindNumbers);
 
-      // Tab-key navigation between form fields.
-      // Each case maps a field ID (with digits stripped) to the next field to focus.
-      // IMPORTANT: Adding a new form field requires adding a new case here.
-      // Silent failure: if the resolved focusID doesn't exist in the DOM, focus is
-      // simply not moved (see "No next node" branch below). No error is thrown.
       switch (numlessID) {
         //Board - Special Rule
         case "ruleNameInput":

--- a/src/routes/power-cards/power-card.svelte
+++ b/src/routes/power-cards/power-card.svelte
@@ -254,6 +254,7 @@
               class="input"
               type="text"
               placeholder="Power Name"
+              data-next-field={`cardCost${i}`}
               on:blur={updatePowerName(card, i, "name")}
               on:keydown={nextNode}
               on:focus={selectNode}
@@ -272,6 +273,7 @@
               style="width:3rem; text-align:center;"
               type="text"
               placeholder="Cost"
+              data-next-field={`cardRange${i}`}
               on:blur={updatePowerName(card, i, "cost")}
               on:keydown={nextNode}
               on:focus={selectNode}
@@ -371,6 +373,7 @@
               class="input is-small"
               type="text"
               placeholder="Range"
+              data-next-field={`cardTarget${i}`}
               on:keydown={nextNode}
               on:blur={updatePowerName(card, i, "range")}
               on:focus={selectNode}
@@ -386,6 +389,7 @@
                 elementType="input"
                 placeholder="Target"
                 classNames="is-small"
+                nextField="cardRules{i}"
                 validAutoCompleteValues={iconValuesSorted}
                 additionalOnBlurFunction={() => updatePowerName(card, i, "target")}
                 bind:value={card.target} />
@@ -441,6 +445,7 @@
               style="width:35%"
               type="text"
               placeholder="Elemental Conditions"
+              data-next-field={`cardThreshold${i}`}
               on:blur={updatePowerName(card, i, "thresholdCondition")}
               on:keydown={nextNode}
               bind:value={card.thresholdCondition} />

--- a/src/routes/scenario/name-difficulty-image.svelte
+++ b/src/routes/scenario/name-difficulty-image.svelte
@@ -30,6 +30,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="baseDifficulty"
           on:keydown={nextNode}
           on:focus={selectNode}
           bind:value={scenario.info.name} />

--- a/src/routes/spirit-board-back/name-art-lore.svelte
+++ b/src/routes/spirit-board-back/name-art-lore.svelte
@@ -38,6 +38,7 @@
           class="input"
           type="text"
           placeholder="Name"
+          data-next-field="spiritLoreInput"
           on:focus={selectNode}
           on:keydown={nextNode}
           bind:value={spiritBoardBack.nameImage.name} />

--- a/src/routes/spirit-board-back/setup-playstyle-complexity-powers.svelte
+++ b/src/routes/spirit-board-back/setup-playstyle-complexity-powers.svelte
@@ -33,6 +33,7 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
+        nextField="spiritLorePlaystyle"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={spiritBoardBack.setup.setupText} />
     </div>
@@ -48,6 +49,7 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
+        nextField="spiritLoreComplexity"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={spiritBoardBack.playStyle.playStyleText} />
     </div>
@@ -64,6 +66,7 @@
           class="input"
           type="text"
           placeholder="Complexity Description"
+          data-next-field="spiritLoreComplexityValue"
           on:focus={selectNode}
           on:keydown={nextNode}
           bind:value={spiritBoardBack.complexity.complexityDescriptor} />
@@ -74,6 +77,7 @@
           class="input"
           type="text"
           placeholder="Complexity Value (1-10)"
+          data-next-field="spiritLoreOffense"
           on:focus={selectNode}
           on:keydown={nextNode}
           bind:value={spiritBoardBack.complexity.complexityValue} />
@@ -97,6 +101,7 @@
             class="input"
             type="text"
             placeholder="Offense Value (1-10)"
+            data-next-field="spiritLoreControl"
             on:focus={selectNode}
             on:keydown={nextNode}
             bind:value={spiritBoardBack.summary.offenseValue} />
@@ -115,6 +120,7 @@
             class="input"
             type="text"
             placeholder="Control Value (1-10)"
+            data-next-field="spiritLoreFear"
             on:focus={selectNode}
             on:keydown={nextNode}
             bind:value={spiritBoardBack.summary.controlValue} />
@@ -133,6 +139,7 @@
             class="input"
             type="text"
             placeholder="Fear Value (1-10)"
+            data-next-field="spiritLoreDefense"
             on:focus={selectNode}
             on:keydown={nextNode}
             bind:value={spiritBoardBack.summary.fearValue} />
@@ -151,6 +158,7 @@
             class="input"
             type="text"
             placeholder="Defense Value (1-10)"
+            data-next-field="spiritLoreUtility"
             on:focus={selectNode}
             on:keydown={nextNode}
             bind:value={spiritBoardBack.summary.defenseValue} />
@@ -169,6 +177,7 @@
             class="input"
             type="text"
             placeholder="Utility Value (1-10)"
+            data-next-field="spiritLoreUses"
             on:focus={selectNode}
             on:keydown={nextNode}
             bind:value={spiritBoardBack.summary.utilityValue} />
@@ -188,6 +197,7 @@
             style="width:100%; min-width:20rem;"
             type="text"
             placeholder="Uses tokens/icons ie. 'badlands,wilds'"
+            data-next-field="spiritLoreNote"
             on:focus={selectNode}
             on:keydown={nextNode}
             bind:value={spiritBoardBack.summary.usesTokens} />

--- a/src/routes/spirit-board/growth.svelte
+++ b/src/routes/spirit-board/growth.svelte
@@ -334,6 +334,7 @@
         class="input is-small"
         type="text"
         placeholder="Growth Directions (ie. &quot;Pick Two&quot;)"
+        data-next-field="growthSet0Group0Action0"
         on:keydown={nextNode}
         bind:value={spiritBoard.growth.directions} />
     </div>
@@ -370,6 +371,7 @@
               style="width:70%;"
               type="text"
               placeholder="Growth Set Choice ie. (PICK ONE OF)"
+              data-next-field="growthSet{i}Group0Action0"
               on:keydown={nextNode}
               bind:value={growthSet.choiceText} />
           </div>
@@ -423,6 +425,8 @@
                       class="input  is-small"
                       type="text"
                       placeholder="Try &quot;2&quot; or &quot;3,dahan&quot;"
+                      data-next-field="set{i}group{j}tint"
+                      data-next-field-default="growthSet{i}Group{j}Action0"
                       on:keydown={nextNode}
                       bind:value={growthGroup.cost} />
                   </div>
@@ -440,6 +444,8 @@
                       class="input  is-small"
                       type="text"
                       placeholder="Try &quot;blue&quot; or &quot;#ff0058&quot;"
+                      data-next-field="set{i}group{j}title"
+                      data-next-field-default="growthSet{i}Group{j}Action0"
                       on:keydown={nextNode}
                       bind:value={growthGroup.tint} />
                   </div>
@@ -457,6 +463,7 @@
                       class="input  is-small"
                       type="text"
                       placeholder="Try &quot;Max 1/Game&quot;"
+                      data-next-field="growthSet{i}Group{j}Action0"
                       on:keydown={nextNode}
                       bind:value={growthGroup.title} />
                   </div>
@@ -495,6 +502,8 @@
                       elementType="input"
                       classNames="is-small"
                       placeholder="Growth Action"
+                      nextField="growthSet{i}Group{j}Action{k + 1}"
+                      nextFieldDefault="growthSet{i}Group{j}AddAction"
                       showListImmediately={true}
                       validAutoCompleteValues={growthValuesSorted}
                       additionalOnBlurFunction={() => updateGrowthActionLocal(i, j, k)}

--- a/src/routes/spirit-board/innate-powers.svelte
+++ b/src/routes/spirit-board/innate-powers.svelte
@@ -244,6 +244,7 @@
             class="input"
             type="text"
             placeholder="Power Name"
+            data-next-field="powerRange{i}"
             on:keydown={nextNode}
             on:focus={selectNode}
             bind:value={innatePower.name} />
@@ -318,6 +319,7 @@
               class="input is-small"
               type="text"
               placeholder="Range"
+              data-next-field="powerTarget{i}"
               on:keydown={nextNode}
               on:focus={selectNode}
               on:blur={updateInnatePowerRange(innatePower, `ip${i}range`)}
@@ -329,6 +331,7 @@
               elementType="input"
               classNames="is-small"
               placeholder="Target"
+              nextField="powerNote{i}"
               validAutoCompleteValues={iconValuesSorted}
               additionalOnBlurFunction={() => updateInnatePowerTarget(innatePower, `ip${i}target`)}
               bind:value={innatePower.target} />
@@ -342,6 +345,8 @@
         elementType="input"
         placeholder="Note (optional)"
         classNames="is-small"
+        nextField="power{i}levelThreshold0"
+        nextFieldDefault="power{i}addLevel"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={innatePower.note} />
     </div>
@@ -353,6 +358,7 @@
             class="input is-small small-power"
             type="text"
             placeholder="Threshold"
+            data-next-field="power{i}levelEffect{j}"
             on:focus={selectNode}
             on:blur={updateInnatePowerThreshold(level, `ip${i}L${j}t`)}
             on:keydown={nextNode}
@@ -364,6 +370,8 @@
             elementType="textarea"
             placeholder="Effect"
             classNames="is-small small-power"
+            nextField="power{i}levelThreshold{j + 1}"
+            nextFieldDefault="power{i}addLevel"
             validAutoCompleteValues={iconValuesSorted}
             additionalOnBlurFunction={() => updateInnatePowerEffect(level, `ip${i}L${j}`)}
             bind:value={level.effect} />

--- a/src/routes/spirit-board/presence-tracks.svelte
+++ b/src/routes/spirit-board/presence-tracks.svelte
@@ -144,6 +144,8 @@
               id={`energy${i}builder`}
               class="input is-small presence-input-block"
               type="text"
+              data-next-field="energy{i + 1}builder"
+              data-next-field-default="energy{i}builderadd"
               on:focus={selectNode}
               on:blur={() => updatePresenceNodeLocal()}
               on:keydown={nextNode}
@@ -185,6 +187,8 @@
               id={`plays${i}builder`}
               class="input is-small presence-input-block"
               type="text"
+              data-next-field="plays{i + 1}builder"
+              data-next-field-default="plays{i}builderadd"
               on:blur={() => updatePresenceNodeLocal}
               on:focus={selectNode}
               on:keydown={nextNode}
@@ -232,6 +236,8 @@
                   id={`additional${t}node${i}builder`}
                   class="input is-small presence-input-block"
                   type="text"
+                  data-next-field="additional{t}node{i + 1}builder"
+                  data-next-field-default="additional{t}node{i}builderadd"
                   on:focus={selectNode}
                   on:keydown={nextNode}
                   bind:value={additionalNode.effect} />

--- a/src/routes/spirit-board/special-rules.svelte
+++ b/src/routes/spirit-board/special-rules.svelte
@@ -86,6 +86,7 @@
             class="input"
             type="text"
             placeholder="Name"
+            data-next-field="ruleEffectInput{i}"
             on:focus={selectNode}
             on:keydown={nextNode}
             on:blur={() => updateSpecialRule(rule, i, "name")}
@@ -96,6 +97,8 @@
         id={`ruleEffectInput${i}`}
         elementType="textarea"
         placeholder="Effect"
+        nextField="ruleNameInput{i + 1}"
+        nextFieldDefault="addSpecialRule"
         validAutoCompleteValues={iconValuesSorted}
         additionalOnBlurFunction={() => updateSpecialRule(rule, i, "effect")}
         bind:value={rule.effect} />


### PR DESCRIPTION
Move field navigation knowledge from the centralized switch statement in lib.js nextNode into data-next-field and data-next-field-default HTML attributes on each form field. AutoComplete component now accepts nextField and nextFieldDefault props and forwards them as data attributes.